### PR TITLE
add support for NY state primary to countdown clock

### DIFF
--- a/addon/components/election-countdown.js
+++ b/addon/components/election-countdown.js
@@ -9,7 +9,16 @@ export default CountDown.extend({
   // put this in config/environment.js when import error gets resolved
   calendarLink: '/assets/midterms.ics',
 
+  diffUntilPrimary() {
+    this.set('to', this.primaryDayStart);
+    return this.diff();
+  },
+
   electionDayEveStart: '2018-11-05T00:00:00.000-05:00',
   electionDayStart: '2018-11-06T00:00:00.000-05:00',
   electionDayEnd: '2018-11-07T00:00:00.000-05:00'
+
+  primaryDayEveStart: '2018-09-12T00:00:00.000-05:00',
+  primaryDayStart: '2018-09-13T00:00:00.000-05:00',
+  primaryDayEnd: '2018-09-14T00:00:00.000-05:00'
 });

--- a/addon/components/election-countdown.js
+++ b/addon/components/election-countdown.js
@@ -1,5 +1,8 @@
 import layout from '../templates/components/election-countdown';
 import CountDown from 'nypr-countdown/components/count-down';
+import { computed } from '@ember/object';
+
+import moment from 'moment';
 
 export default CountDown.extend({
   layout,
@@ -9,10 +12,18 @@ export default CountDown.extend({
   // put this in config/environment.js when import error gets resolved
   calendarLink: '/assets/midterms.ics',
 
-  diffUntilPrimary() {
-    this.set('to', this.primaryDayStart);
-    return this.diff();
-  },
+  diffUntilPrimary: computed('from', 'to', 'unit', function() {
+    // let's do this the quick n redundant way
+    let { from, to, unit, timezone, primaryDayStart } = this;
+    from = moment.tz(from, timezone);
+    to = moment.tz(primaryDayStart, timezone);
+
+    if (isNaN(from) || isNaN(to)) return;
+
+    let value = moment.duration(to.diff(from)).as(unit);
+    return Math.round(value);
+
+  }),
 
   electionDayEveStart: '2018-11-05T00:00:00.000-05:00',
   electionDayStart: '2018-11-06T00:00:00.000-05:00',

--- a/addon/components/election-countdown.js
+++ b/addon/components/election-countdown.js
@@ -16,7 +16,7 @@ export default CountDown.extend({
 
   electionDayEveStart: '2018-11-05T00:00:00.000-05:00',
   electionDayStart: '2018-11-06T00:00:00.000-05:00',
-  electionDayEnd: '2018-11-07T00:00:00.000-05:00'
+  electionDayEnd: '2018-11-07T00:00:00.000-05:00',
 
   primaryDayEveStart: '2018-09-12T00:00:00.000-05:00',
   primaryDayStart: '2018-09-13T00:00:00.000-05:00',

--- a/addon/templates/components/election-countdown.hbs
+++ b/addon/templates/components/election-countdown.hbs
@@ -1,8 +1,11 @@
 {{#if (is-between primaryDayStart primaryDayEnd)}}
 
-  <div class="election-countdown__header">Today is NY State Primary Election Day</div>
+  <div class="election-countdown__left primaries">
+    <div class="election-countdown__header">Today is NY State Primary Election Day</div>
+  </div>
+
   {{#unless promo}}
-    <div class="election-countdown__right">
+    <div class="election-countdown__right primaries">
       <div class="election-countdown__get-updates">
         + {{#link-to 'opt-in'}}Get Updates{{/link-to}}
       </div>
@@ -11,7 +14,7 @@
 
 {{else if (is-before primaryDayStart)}}
 
-  <div class="election-countdown__left">
+  <div class="election-countdown__left primaries">
     <div class="election-countdown__diff">{{diffUntilPrimary}}</div>
     <div class="election-countdown__header">
       {{if (is-before primaryDayEveStart) "Days" "Day"}} Until the NY State Primary Election
@@ -19,7 +22,7 @@
   </div>
 
   {{#unless promo}}
-    <div class="election-countdown__right">
+    <div class="election-countdown__right primaries">
       <div class="election-countdown__get-updates">
         + {{#link-to 'opt-in'}}Get Updates{{/link-to}}
       </div>
@@ -28,7 +31,10 @@
 
 {{else if (is-between electionDayStart electionDayEnd)}}
 
-  <div class="election-countdown__header">Election Day is Today!</div>
+  <div class="election-countdown__left">
+    <div class="election-countdown__header">Election Day is Today!</div>
+  </div>
+
   {{#unless promo}}
     <div class="election-countdown__share-voting-issues">
       + <a href="#">Share Voting Issues</a>
@@ -40,7 +46,10 @@
 
 {{else if (is-after electionDayEnd)}}
 
-  <div class="election-countdown__header">Ready for the Next Election?</div>
+  <div class="election-countdown__left">
+    <div class="election-countdown__header">Ready for the Next Election?</div>
+  </div>
+
   {{#unless promo}}
     <div class="election-countdown__share-your-experience">
       + <a href="#">Share Your Experience</a>

--- a/addon/templates/components/election-countdown.hbs
+++ b/addon/templates/components/election-countdown.hbs
@@ -1,4 +1,32 @@
-{{#if (is-between electionDayStart electionDayEnd)}}
+{{#if (is-between primaryDayStart primaryDayEnd)}}
+
+  <div class="election-countdown__header">Today is NY State Primary Election Day</div>
+  {{#unless promo}}
+    <div class="election-countdown__right">
+      <div class="election-countdown__get-updates">
+        + {{#link-to 'opt-in'}}Get Updates{{/link-to}}
+      </div>
+    </div>
+  {{/unless}}
+
+{{else if (is-before primaryDayStart)}}
+
+  <div class="election-countdown__left">
+    <div class="election-countdown__diff">{{diffUntilPrimary}}</div>
+    <div class="election-countdown__header">
+      {{if (is-before primaryDayEveStart) "Days" "Day"}} Until the NY State Primary Election
+    </div>
+  </div>
+
+  {{#unless promo}}
+    <div class="election-countdown__right">
+      <div class="election-countdown__get-updates">
+        + {{#link-to 'opt-in'}}Get Updates{{/link-to}}
+      </div>
+    </div>
+  {{/unless}}
+
+{{else if (is-between electionDayStart electionDayEnd)}}
 
   <div class="election-countdown__header">Election Day is Today!</div>
   {{#unless promo}}

--- a/app/styles/election-countdown/_election-countdown-module.scss
+++ b/app/styles/election-countdown/_election-countdown-module.scss
@@ -5,7 +5,7 @@
   background-color: $col-azul;
   color: $col-white;
   display: flex;
-  font-size: 1.4rem;
+  font-size: 14px;
   padding: 16px;
   text-align: left;
   height: 70px;
@@ -19,13 +19,21 @@
     align-items: center;
     display: flex;
     font-family: $font-montserrat;
-    font-size: 1.6rem;
+    font-size: 16px;
     font-weight: 600;
     line-height: 1.38;
     width: 60%;
 
     @include media('>=medium') {
       width: 50%;
+    }
+
+    &.primaries {
+      width: 70%;
+
+      @include media('>=medium') {
+        width: 60%;
+      }
     }
   }
 
@@ -43,10 +51,18 @@
       justify-content: flex-end;
       width: 50%;
     }
+
+    &.primaries {
+      width: 30%;
+
+      @include media('>=medium') {
+        width: 40%;
+      }
+    }
   }
 
   &__diff {
-    font-size: 4.4rem;
+    font-size: 44px;
     line-height: .5;
     margin-right: 16px;
   }

--- a/app/styles/election-countdown/_election-countdown-promo.scss
+++ b/app/styles/election-countdown/_election-countdown-promo.scss
@@ -121,24 +121,26 @@
   margin-left: 5px;
 }
 
-.election-countdown__left {
-  display: flex;
-  font-size: 12px;
-  border-bottom: 1px solid white;
-  line-height: 1;
+.election-promo {
+  .election-countdown__left {
+    display: flex;
+    font-size: 12px;
+    border-bottom: 1px solid white;
+    line-height: 1;
 
-  @include media(">=small") {
-    font-size: 16px;
+    @include media(">=small") {
+      font-size: 16px;
+    }
+
+    @include media(">=medium") {
+      font-size: 24px;
+    }
   }
 
-  @include media(">=medium") {
-    font-size: 24px;
+  .election-countdown__diff {
+    font-weight: bold;
+    margin-right: 5px;
   }
-}
-
-.election-countdown__left .election-countdown__diff {
-  font-weight: bold;
-  margin-right: 5px;
 }
 
 .promo-opt-in {

--- a/tests/integration/components/election-countdown-test.js
+++ b/tests/integration/components/election-countdown-test.js
@@ -11,54 +11,105 @@ module('Integration | Component | election-countdown', function(hooks) {
   setupRenderingTest(hooks);
 
   test('usage', async function(assert) {
-    const NOW = moment().tz(TIMEZONE); // today
-    const ONE_YEAR_FROM_NOW = NOW.clone().add(1, 'year');
+    const PRIMARY = moment.tz(this.get('primaryDayStart'), TIMEZONE);
+    const GENERAL = moment.tz(this.get('electionDayStart'), TIMEZONE);
 
-    this.set('from', NOW);
-    this.set('to', ONE_YEAR_FROM_NOW);
+    // Sept primary election tests:
+    const ONE_YEAR_BEFORE_PRIMARY = PRIMARY.clone().subtract(1, 'year').add(23, 'hours');
+    this.set('to', PRIMARY);
+
+    this.set('from', ONE_YEAR_BEFORE_PRIMARY);
     await render(hbs`
       {{election-countdown
         from=from
         to=to
         unit='days'
-        electionDayStart=to
+      }}
+    `);
+    assert.dom('.election-countdown').hasText('365 Days Until the NY State Primary Election + Get Updates');
+
+    this.set('from', PRIMARY.clone().subtract(1, 'hours'));
+    this.set('primaryDayEveStart', PRIMARY.clone().subtract(2, 'hours'));
+    await render(hbs`
+      {{election-countdown
+        from=from
+        to=to
+        unit='days'
+        primaryDayEveStart=primaryDayEveStart
+      }}
+    `);
+    assert.dom('.election-countdown').hasText('1 Day Until the NY State Primary Election + Get Updates');
+
+    this.set('from', PRIMARY.clone());
+    this.set('primaryDayStart', PRIMARY.clone().subtract(2, 'days'));
+    this.set('primaryDayEnd', PRIMARY.clone().add(2, 'days'));
+    await render(hbs`
+      {{election-countdown
+        from=from
+        to=to
+        unit='days'
+        primaryDayStart=primaryDayStart
+        primaryDayEnd=primaryDayEnd
+      }}
+    `);
+    assert.dom('.election-countdown').hasText('Today is NY State Primary Election Day + Get Updates');
+
+    // Nov midterm election tests:
+    //
+    const ONE_YEAR_BEFORE_GENERAL = GENERAL.clone().subtract(1, 'year');
+    this.set('to', GENERAL);
+    this.set('primaryDayStart', GENERAL.clone().subtract(2, 'years')); // primaries are over
+    this.set('primaryDayEnd', GENERAL.clone().subtract(2, 'years')); // primaries are over
+
+    this.set('from', ONE_YEAR_BEFORE_GENERAL);
+    await render(hbs`
+      {{election-countdown
+        from=from
+        to=to
+        unit='days'
+        primaryDayStart=primaryDayStart
+        primaryDayEnd=primaryDayEnd
       }}
     `);
     assert.dom('.election-countdown').hasText('365 Days Until Elections + Add to Cal + Get Updates');
 
-    this.set('to', NOW.clone().add(1, 'days'));
-    this.set('electionDayEveStart', NOW.clone().subtract(1, 'days'))
+    this.set('from', GENERAL.clone().subtract(1, 'days'));
     await render(hbs`
       {{election-countdown
         from=from
         to=to
         unit='days'
+        primaryDayStart=primaryDayStart
+        primaryDayEnd=primaryDayEnd
         electionDayEveStart=electionDayEveStart
-        electionDayStart=to
       }}
     `);
     assert.dom('.election-countdown').hasText('1 Day Until Elections + Add to Cal + Get Updates');
 
-    this.set('to', NOW.clone().subtract(1, 'hours'));
-    this.set('electionDayStart', NOW.clone().subtract(1, 'days'))
-    this.set('electionDayEnd', NOW.clone().add(2, 'days'))
+    this.set('from', GENERAL.clone())
+    this.set('electionDayStart', GENERAL.clone().subtract(1, 'days'))
+    this.set('electionDayEnd', GENERAL.clone().add(1, 'days'))
     await render(hbs`
       {{election-countdown
         from=from
         to=to
         unit='days'
+        primaryDayStart=primaryDayStart
+        primaryDayEnd=primaryDayEnd
         electionDayStart=electionDayStart
         electionDayEnd=electionDayEnd
       }}
     `);
     assert.dom('.election-countdown').hasText('Election Day is Today! + Share Voting Issues + Find Polling Place');
 
-    this.set('to', NOW.clone().subtract(5, 'days'));
+    this.set('from', GENERAL.clone().subtract(5, 'days'));
     await render(hbs`
       {{election-countdown
         from=from
         to=to
         unit='days'
+        primaryDayStart=primaryDayStart
+        primaryDayEnd=primaryDayEnd
         electionDayEnd=to
       }}
     `);


### PR DESCRIPTION
This adds support for counting down to NY state primary day. The date checking is handled just in the addon so we don't have to update the helper call in the consuming app after this Thursday. 